### PR TITLE
update validate functions and change the compose function implementation

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -1,10 +1,5 @@
 package models
 
-import (
-	"encoding/json"
-	"errors"
-)
-
 type MessageBlockType string
 
 const (
@@ -16,7 +11,7 @@ const (
 
 type IBlock interface {
 	BlockType() MessageBlockType
-	Validate() bool
+	Validate() error
 }
 
 type Block struct {
@@ -28,17 +23,12 @@ func (ths *Block) BlockType() MessageBlockType {
 	return ths.Type
 }
 
-func Compose(block IBlock) ([]byte, error) {
-	if !block.Validate() {
-		return nil, errors.New("invalid block")
+func validateBlock(block IBlock) error {
+	if err := block.Validate(); err != nil {
+		return err
 	}
 
-	res, err := json.Marshal(block)
-	if err != nil {
-		return nil, errors.New("error when marshaling block")
-	}
-
-	return res, nil
+	return nil
 }
 
 func NewBlock() *Block {

--- a/models/blockContainer.go
+++ b/models/blockContainer.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"errors"
+	"fmt"
+)
+
 type ContainerBlock struct {
 	Block
 	Container *ContainerBlockObject `json:"container"`
@@ -10,10 +15,26 @@ type ContainerBlockObject struct {
 	Direction string `json:"direction"`
 }
 
-func (s ContainerBlock) Validate() bool {
+func (s ContainerBlock) Validate() error {
 	// ContainerBlock validation implementation
+	if s.Type != "container" {
+		return errors.New("invalid container block type")
+	}
 
-	return true
+	switch s.Container.Direction {
+	case "row": // add more available value here
+		break
+	default:
+		return errors.New("invalid container direction")
+	}
+
+	for i, v := range s.Container.Blocks {
+		if err := v.Validate(); err != nil {
+			return fmt.Errorf("Container.Blocks index %d: %s", i, err.Error())
+		}
+	}
+
+	return nil
 }
 
 // NewContainerBlock returns a new instance of a section block to be rendered

--- a/models/blockImage.go
+++ b/models/blockImage.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"errors"
+	"regexp"
+)
+
 type ImageBlock struct {
 	Block
 	Image *ImageBlockObject `json:"image"`
@@ -11,10 +16,17 @@ type ImageBlockObject struct {
 	Alt string `json:"alt"`
 }
 
-func (s ImageBlock) Validate() bool {
+func (s ImageBlock) Validate() error {
 	// ImageBlock validation implementation
+	if s.Type != "image" {
+		return errors.New("invalid image block type")
+	}
 
-	return true
+	if match, _ := regexp.MatchString("^(http(s?):)([/|.|\\w|\\s|-])*\\.(?:jpg|jpeg|gif|png)$", s.Image.Src); !match {
+		return errors.New("invalid image src")
+	}
+
+	return nil
 }
 
 // NewImageBlock returns a new instance of a section block to be rendered

--- a/models/blockTable.go
+++ b/models/blockTable.go
@@ -23,10 +23,10 @@ type TextHeaderObject struct {
 	Body  string `json:"body"`
 }
 
-func (s TableBlock) Validate() bool {
+func (s TableBlock) Validate() error {
 	// TableBlock validation implementation
 
-	return true
+	return nil
 }
 
 // NewTableBlock returns a new instance of a section block to be rendered

--- a/models/blockText.go
+++ b/models/blockText.go
@@ -12,10 +12,10 @@ type TextBlockObject struct {
 	Body string `json:"body"`
 }
 
-func (s TextBlock) Validate() bool {
+func (s TextBlock) Validate() error {
 	// TextBlock validation implementation
 
-	return true
+	return nil
 }
 
 // NewTextBlock returns a new instance of a section block to be rendered

--- a/models/component.go
+++ b/models/component.go
@@ -1,5 +1,11 @@
 package models
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
 type MessageComponentType string
 
 const (
@@ -10,6 +16,7 @@ const (
 type IComponent interface {
 	NewDialog() *Component
 	NewDrawer() *Component
+	Compose() ([]byte, []error)
 }
 
 type Component struct {
@@ -33,4 +40,26 @@ func (c *Component) NewDrawer() *Component {
 	return &Component{
 		Type: MCTDrawer,
 	}
+}
+
+func (c *Component) Compose() ([]byte, []error) {
+	var errs []error
+
+	for i, v := range c.Blocks {
+		if err := validateBlock(v); err != nil {
+			err := fmt.Errorf("component.Blocks index %d: %s", i, err.Error())
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	res, err := json.Marshal(c)
+	if err != nil {
+		return nil, []error{errors.New("error when marshaling block")}
+	}
+
+	return res, nil
 }

--- a/sirchat.go
+++ b/sirchat.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/sirclo-solution/sirchat/models"
@@ -22,8 +21,13 @@ func main() {
 		Body: "Cari Produk",
 	})
 
+	textBlock2 := models.NewTextBlock(&models.TextBlockObject{
+		Type: "label",
+		Body: "a dummy text",
+	})
+
 	imageBlock := models.NewImageBlock(&models.ImageBlockObject{
-		Src: "https://example.com/dummy.jpg",
+		Src: "https://example.com/dummy.jpg", // change to invalid url like "https://example.com/dummy.m4a" to induce error
 		Alt: "a dummy image",
 	})
 
@@ -31,12 +35,25 @@ func main() {
 		Direction: "row",
 	})
 
+	containerBlock2 := models.NewContainerBlock(&models.ContainerBlockObject{
+		Direction: "row",
+	})
+
+	containerBlock3 := models.NewContainerBlock(&models.ContainerBlockObject{
+		Direction: "row", // change to something like "fake_row" to induce error
+	})
+
+	containerBlock3.Container.AddBlock(textBlock2)
+
+	containerBlock2.Container.AddBlock(containerBlock3)
+
 	containerBlock.Container.AddBlock(imageBlock)
 
-	newDialog.Blocks = append(newDialog.Blocks, textBlock, containerBlock)
-	result, err := json.Marshal(newDialog)
-	if err != nil {
-		panic(err)
+	newDialog.Blocks = append(newDialog.Blocks, textBlock, containerBlock, containerBlock2)
+	result, errs := newDialog.Compose()
+	if errs != nil {
+		fmt.Printf("%+q\n", errs)
+		return
 	}
 	fmt.Printf("Result : %v\n", string(result))
 }


### PR DESCRIPTION
- Added implementation of `Validate()` method for `ContainerBlock` and `ImageBlock`
- Changed the implementation of `Compose()` function in package models to `validateBlock()`
- Added new method in interface `IComponent`
- Updated the example. New way to compose the component to json. There also some examples to induce error when calling `Compose()` method